### PR TITLE
Improve configuration meta-data

### DIFF
--- a/twitter4j-spring-boot-autoconfigure/src/main/java/com/sivalabs/spring/boot/autoconfigure/Twitter4jAutoConfiguration.java
+++ b/twitter4j-spring-boot-autoconfigure/src/main/java/com/sivalabs/spring/boot/autoconfigure/Twitter4jAutoConfiguration.java
@@ -44,7 +44,7 @@ public class Twitter4jAutoConfiguration {
 		}
 		
 		ConfigurationBuilder cb = new ConfigurationBuilder();
-		cb.setDebugEnabled(properties.getDebug())
+		cb.setDebugEnabled(properties.isDebug())
 		  .setOAuthConsumerKey(properties.getOauth().getConsumerKey())
 		  .setOAuthConsumerSecret(properties.getOauth().getConsumerSecret())
 		  .setOAuthAccessToken(properties.getOauth().getAccessToken())

--- a/twitter4j-spring-boot-autoconfigure/src/main/java/com/sivalabs/spring/boot/autoconfigure/Twitter4jProperties.java
+++ b/twitter4j-spring-boot-autoconfigure/src/main/java/com/sivalabs/spring/boot/autoconfigure/Twitter4jProperties.java
@@ -4,7 +4,6 @@
 package com.sivalabs.spring.boot.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * @author Siva
@@ -14,17 +13,19 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 public class Twitter4jProperties {
 	
 	public static final String TWITTER4J_PREFIX = "twitter4j";
+
+	/**
+	 * Enables deubg output. Effective only with the embedded logger.
+	 */
+	private boolean debug = false;
 	
-	private Boolean debug = false;
-	
-	@NestedConfigurationProperty
-	private OAuth oauth = new OAuth();
-	
-	public Boolean getDebug() {
+	private final OAuth oauth = new OAuth();
+
+	public boolean isDebug() {
 		return debug;
 	}
 
-	public void setDebug(Boolean debug) {
+	public void setDebug(boolean debug) {
 		this.debug = debug;
 	}
 
@@ -32,15 +33,26 @@ public class Twitter4jProperties {
 		return oauth;
 	}
 
-	public void setOauth(OAuth oauth) {
-		this.oauth = oauth;
-	}
-
 	public static class OAuth {
-		
+
+		/**
+		 * OAuth consumer key.
+		 */
 		private String consumerKey;
+
+		/**
+		 * OAuth consumer secret.
+		 */
 		private String consumerSecret;
+
+		/**
+		 * OAuth access token.
+		 */
 		private String accessToken;
+
+		/**
+		 * OAuth access token secret.
+		 */
 		private String accessTokenSecret;
 		
 		public String getConsumerKey() {


### PR DESCRIPTION
If a nested group is defined by an inner class of the current
configuration class, there is no need to flag it with
`@NestedConfigurationProperty`. And there is not need to provide a setter
as long as the instance is available (i.e. making it final is a best
practice unless you want to lazily create it).

Also all keys were missing documentation which are self-explanatory here
but it doesn't hurt.

On a completely separate note, I am glad to see that your module names respect [the naming convention for 3rd party starters](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-custom-starter-naming). I think that it would be more consistent if the github project was named consistently (you can rename it in the settings section if you're ok with that change).